### PR TITLE
Update to React 0.14

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
         },
         module: {
           loaders: [
-            {test: /\.jsx$/, loader: 'jsx'}
+            {test: /\.jsx$/, loader: 'babel'}
           ]
         },
         externals: {

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
 </head>
 <body>
   <div id="griddle-callback"></div>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.12.1/react.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.14.3/react.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.14.3/react-dom.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/react/0.12.1/JSXTransformer.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js"></script>
     <script src="build/GriddleWithCallback.js"></script>
@@ -38,6 +39,6 @@
         }
       });
 
-      React.render(<GriddleWithCallback getExternalResults={loadData} loadingComponent={Loading} enableSort={true} enableInfiniteScroll={true} bodyHeight={200} columns={["name", "model", "manufacturer", "passengers"]} resultsPerPage={10} showFilter={false} showSettings={false} />, document.getElementById('griddle-callback')); 
+      ReactDOM.render(<GriddleWithCallback getExternalResults={loadData} loadingComponent={Loading} enableSort={true} enableInfiniteScroll={true} bodyHeight={200} columns={["name", "model", "manufacturer", "passengers"]} resultsPerPage={10} showFilter={false} showSettings={false} />, document.getElementById('griddle-callback'));
     </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "Ryan Lanciaux",
   "license": "MIT",
   "dependencies": {
-    "react": "~0.12.0",
+    "react": "0.14.3",
+    "react-dom": "0.14.3",
     "react-tools": "~0.12.0",
     "underscore": "~1.6.0",
     "griddle-react": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "griddle-react": "^0.2.0"
   },
   "devDependencies": {
+    "babel-loader": "^5.3.3",
     "griddle-react": "^0.2.8",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "~0.6.0",
@@ -31,10 +32,9 @@
     "grunt-jsxhint": "^0.4.0",
     "grunt-open": "^0.2.3",
     "grunt-react": "~0.10.0",
-    "grunt-webpack": "~1.0.8",
+    "grunt-webpack": "^1.0.11",
     "jest-cli": "*",
-    "jsx-loader": "~0.12.0",
-    "webpack": "~1.3.3-beta1",
-    "webpack-dev-server": "~1.7.0"
+    "webpack": "1.12.3",
+    "webpack-dev-server": "~1.12.1"
   }
 }


### PR DESCRIPTION
GriddleWithCallback is used in http://griddlegriddle.github.io/Griddle/infiniteScroll.html which has been updated to React 0.14. This build should also use the latest `Griddle`.
